### PR TITLE
Шаблоны на протокол по подразделениям

### DIFF
--- a/api/directions/sql_func.py
+++ b/api/directions/sql_func.py
@@ -608,17 +608,19 @@ def get_total_confirm_direction(d_s, d_e, lab_podr, is_lab=False, is_paraclinic=
     return rows
 
 
-def get_template_research_by_department(research_id, department_id):
+def get_template_research_by_department(research_id, department_id, hide=True):
     with connection.cursor() as cursor:
         cursor.execute(
             """
-                SELECT directory_paraclinictemplatename.id, directory_paraclinictemplatename.title
+                SELECT directory_paraclinictemplatename.id, directory_paraclinictemplatename.title, directory_paraclinictemplatename.hide
                 FROM public.directory_paraclinictemplatenamedepartment
                 INNER JOIN directory_paraclinictemplatename ON 
                 directory_paraclinictemplatenamedepartment.template_name_id = directory_paraclinictemplatename.id
                 WHERE 
                 directory_paraclinictemplatename.research_id = %(research_id)s AND
                 directory_paraclinictemplatenamedepartment.department_id = %(department_id)s
+                directory_paraclinictemplatename.hide = %(hide)s or directory_paraclinictemplatename.hide = false
+                
                 
                 ORDER BY directory_paraclinictemplatename.title
                 
@@ -627,6 +629,7 @@ def get_template_research_by_department(research_id, department_id):
             params={
                 'research_id': research_id,
                 'department_id': department_id,
+                'hide': hide,
             },
         )
         rows = namedtuplefetchall(cursor)

--- a/api/directions/sql_func.py
+++ b/api/directions/sql_func.py
@@ -608,7 +608,7 @@ def get_total_confirm_direction(d_s, d_e, lab_podr, is_lab=False, is_paraclinic=
     return rows
 
 
-def get_template_research_by_department(research_id, department_id, hide=True):
+def get_template_research_by_department(research_id, department_id, hide="true"):
     with connection.cursor() as cursor:
         cursor.execute(
             """
@@ -616,11 +616,10 @@ def get_template_research_by_department(research_id, department_id, hide=True):
                 FROM public.directory_paraclinictemplatenamedepartment
                 INNER JOIN directory_paraclinictemplatename ON 
                 directory_paraclinictemplatenamedepartment.template_name_id = directory_paraclinictemplatename.id
-                WHERE 
+                WHERE
                 directory_paraclinictemplatename.research_id = %(research_id)s AND
-                directory_paraclinictemplatenamedepartment.department_id = %(department_id)s
-                directory_paraclinictemplatename.hide = %(hide)s or directory_paraclinictemplatename.hide = false
-                
+                directory_paraclinictemplatenamedepartment.department_id = %(department_id)s AND
+                (directory_paraclinictemplatename.hide = %(hide)s or directory_paraclinictemplatename.hide = false)
                 
                 ORDER BY directory_paraclinictemplatename.title
                 

--- a/api/directions/views.py
+++ b/api/directions/views.py
@@ -1873,7 +1873,7 @@ def directions_paraclinic_form(request):
 
                 default_template = ParaclinicTemplateName.make_default(i.research)
 
-                if i.research.is_template_by_department:
+                if i.research.template_by_department:
                     templates_by_department = get_template_research_by_department(i.research_id, doc_department_id)
                     templates_data = [{"pk": template.id, "title": template.title} for template in templates_by_department]
                     iss["templates"].append(
@@ -1898,7 +1898,7 @@ def directions_paraclinic_form(request):
                 result_fields = {x.field_id: x for x in ParaclinicResult.objects.filter(issledovaniye=i)}
 
                 fields_templates_by_department_data = None
-                if i.research.is_template_by_department:
+                if i.research.template_by_department:
                     fields_templates_by_department = get_template_field_by_department(i.research_id, doc_department_id)
                     fields_templates_by_department_data = {field_template.field_id: field_template.value for field_template in fields_templates_by_department}
 

--- a/api/directions/views.py
+++ b/api/directions/views.py
@@ -1873,7 +1873,7 @@ def directions_paraclinic_form(request):
 
                 default_template = ParaclinicTemplateName.make_default(i.research)
 
-                if i.research.template_by_department:
+                if i.research.templates_by_department:
                     templates_by_department = get_template_research_by_department(i.research_id, doc_department_id)
                     templates_data = [{"pk": template.id, "title": template.title} for template in templates_by_department]
                     iss["templates"].append(
@@ -1898,7 +1898,7 @@ def directions_paraclinic_form(request):
                 result_fields = {x.field_id: x for x in ParaclinicResult.objects.filter(issledovaniye=i)}
 
                 fields_templates_by_department_data = None
-                if i.research.template_by_department:
+                if i.research.templates_by_department:
                     fields_templates_by_department = get_template_field_by_department(i.research_id, doc_department_id)
                     fields_templates_by_department_data = {field_template.field_id: field_template.value for field_template in fields_templates_by_department}
 

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -445,6 +445,7 @@ def researches_update(request):
         own_form_result = result_current_form > 0
         info = request_data.get("info", "").strip()
         hide = request_data.get("hide")
+        templates_by_department = request_data.get("templates_by_department")
         site_type = request_data.get("site_type", None)
         groups = request_data.get("groups", [])
         tube = request_data.get("tube", -1)
@@ -477,6 +478,7 @@ def researches_update(request):
                     is_paraclinic=not desc and department.p_type == 3,
                     paraclinic_info=info,
                     hide=hide,
+                    templates_by_department=templates_by_department,
                     is_doc_refferal=department_pk == -2,
                     is_treatment=department_pk == -3,
                     is_stom=department_pk == -4,
@@ -539,6 +541,7 @@ def researches_update(request):
                 res.microbiology_tube_id = tube if department_pk == -6 else None
                 res.paraclinic_info = info
                 res.hide = hide
+                res.templates_by_department = templates_by_department
                 res.site_type_id = site_type
                 res.internal_code = internal_code
                 res.uet_refferal_doc = uet_refferal_doc

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -721,7 +721,6 @@ def fast_templates(request):
     ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
 
     if department_id and is_all:
-        print('fdsfsd')
         templates = get_template_research_by_department(research_id, department_id)
     elif department_id and not is_all:
         templates = get_template_research_by_department(research_id, department_id, hide="false")

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -744,7 +744,7 @@ def fast_template_data(request):
     need_template_department = request_data.get("needTemplateDepartment")
     all_departments = request_data.get("allDepartments")
     user_department_id = request.user.doctorprofile.podrazdeleniye.pk
-    p = ParaclinicTemplateName.objects.get(pk=request_data["pk"])
+    p = ParaclinicTemplateName.objects.get(pk=template_pk)
     template_departments_ids = []
     if need_template_department:
         template_departments_ids = ParaclinicTemplateNameDepartment.get_departments_ids(p.pk, all_departments, user_department_id)
@@ -767,11 +767,11 @@ def fast_template_data(request):
 def fast_template_save(request):
     request_data = json.loads(request.body)
     data = request_data["data"]
-    for_departments = data.get("templateDepartmentsIds", [])
+    template_departments_ids = data.get("templateDepartmentsIds", [])
     if request_data["pk"] == -1:
         p = ParaclinicTemplateName(research=DResearches.objects.get(pk=request_data["research_pk"]), title=data["title"], hide=data["hide"])
         p.save()
-        for department in for_departments:
+        for department in template_departments_ids:
             new_template_depart = ParaclinicTemplateNameDepartment(template_name_id=p.pk, department_id=department)
             new_template_depart.save()
     else:
@@ -782,7 +782,7 @@ def fast_template_save(request):
 
         template_department = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=p.pk)
         template_department.delete()
-        for department in for_departments:
+        for department in template_departments_ids:
             new_template_depart = ParaclinicTemplateNameDepartment(template_name_id=p.pk, department_id=department)
             new_template_depart.save()
 

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -729,12 +729,15 @@ def fast_templates(request):
         templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"]).order_by('title')
         if not is_all:
             templates = templates.filter(hide=False)
-    result = [{
-        "pk": template.id,
-        "title": template.title,
-        "hide": template.hide,
-        "readonly": not is_all or template.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
-    } for template in templates]
+    result = [
+        {
+            "pk": template.id,
+            "title": template.title,
+            "hide": template.hide,
+            "readonly": not is_all or template.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
+        }
+        for template in templates
+    ]
 
     return JsonResponse({"data": result})
 

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -445,7 +445,7 @@ def researches_update(request):
         own_form_result = result_current_form > 0
         info = request_data.get("info", "").strip()
         hide = request_data.get("hide")
-        templates_by_department = request_data.get("templates_by_department")
+        templates_by_department = request_data.get("templatesByDepartment")
         site_type = request_data.get("site_type", None)
         groups = request_data.get("groups", [])
         tube = request_data.get("tube", -1)

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -741,8 +741,14 @@ def fast_templates(request):
 
 def fast_template_data(request):
     request_data = json.loads(request.body)
+    template_pk = request_data["pk"]
+    need_template_department = request_data.get("needTemplateDepartment")
+    all_template = request_data.get("allTemplate")
+    user_department_id = request.user.doctorprofile.podrazdeleniye.pk
     p = ParaclinicTemplateName.objects.get(pk=request_data["pk"])
-    template_departments_ids = ParaclinicTemplateNameDepartment.get_departments_ids(p.pk)
+    template_departments_ids = []
+    if need_template_department:
+        template_departments_ids = ParaclinicTemplateNameDepartment.get_departments_ids(p.pk, all_template, user_department_id)
     data = {
         "readonly": p.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
         "hide": p.hide,

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -718,7 +718,7 @@ def fast_templates(request):
     is_all = request_data.get('all', False)
     department_id = request_data.get('department')
 
-    ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
+    default_temlate = ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
 
     if department_id and is_all:
         templates = get_template_research_by_department(research_id, department_id)
@@ -728,13 +728,19 @@ def fast_templates(request):
         templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"]).order_by('title')
         if not is_all:
             templates = templates.filter(hide=False)
-
     result = [{
         "pk": template.id,
         "title": template.title,
         "hide": template.hide,
         "readonly": not is_all or template.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
     } for template in templates]
+
+    result.insert(0, {
+        "pk": default_temlate.id,
+        "title": default_temlate.title,
+        "hide": default_temlate.hide,
+        "readonly": not is_all or default_temlate.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
+    })
 
     return JsonResponse({"data": result})
 
@@ -743,12 +749,12 @@ def fast_template_data(request):
     request_data = json.loads(request.body)
     template_pk = request_data["pk"]
     need_template_department = request_data.get("needTemplateDepartment")
-    all_template = request_data.get("allTemplate")
+    all_departments = request_data.get("allDepartments")
     user_department_id = request.user.doctorprofile.podrazdeleniye.pk
     p = ParaclinicTemplateName.objects.get(pk=request_data["pk"])
     template_departments_ids = []
     if need_template_department:
-        template_departments_ids = ParaclinicTemplateNameDepartment.get_departments_ids(p.pk, all_template, user_department_id)
+        template_departments_ids = ParaclinicTemplateNameDepartment.get_departments_ids(p.pk, all_departments, user_department_id)
     data = {
         "readonly": p.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
         "hide": p.hide,

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -717,17 +717,16 @@ def fast_templates(request):
     research_id = request_data["pk"]
     is_all = request_data.get('all', False)
     department_id = request_data.get('department')
-    if department_id == 'all':
-        department_id = None
 
     ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
 
     if department_id and is_all:
+        print('fdsfsd')
         templates = get_template_research_by_department(research_id, department_id)
     elif department_id and not is_all:
         templates = get_template_research_by_department(research_id, department_id, hide="false")
     else:
-        templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"])
+        templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"]).order_by('title')
         if not is_all:
             templates = templates.filter(hide=False)
 

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -723,7 +723,7 @@ def fast_templates(request):
     if department_id and is_all:
         templates = get_template_research_by_department(research_id, department_id)
     elif department_id and not is_all:
-        templates = get_template_research_by_department(research_id, department_id, hide=False)
+        templates = get_template_research_by_department(research_id, department_id, hide="false")
     else:
         templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"])
         if not is_all:

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -718,7 +718,7 @@ def fast_templates(request):
     is_all = request_data.get('all', False)
     department_id = request_data.get('department')
 
-    default_temlate = ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
+    ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
 
     if department_id and is_all:
         templates = get_template_research_by_department(research_id, department_id)
@@ -734,13 +734,6 @@ def fast_templates(request):
         "hide": template.hide,
         "readonly": not is_all or template.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
     } for template in templates]
-
-    result.insert(0, {
-        "pk": default_temlate.id,
-        "title": default_temlate.title,
-        "hide": default_temlate.hide,
-        "readonly": not is_all or default_temlate.title == ParaclinicTemplateName.DEFAULT_TEMPLATE_TITLE,
-    })
 
     return JsonResponse({"data": result})
 

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -717,6 +717,8 @@ def fast_templates(request):
     research_id = request_data["pk"]
     is_all = request_data.get('all', False)
     department_id = request_data.get('department')
+    if department_id == 'all':
+        department_id = None
 
     ParaclinicTemplateName.make_default(DResearches.objects.get(pk=research_id))
 
@@ -727,7 +729,7 @@ def fast_templates(request):
     else:
         templates = ParaclinicTemplateName.objects.filter(research__pk=request_data["pk"])
         if not is_all:
-            rts = templates.filter(hide=False)
+            templates = templates.filter(hide=False)
 
     result = [{
         "pk": template.id,

--- a/api/researches/views.py
+++ b/api/researches/views.py
@@ -29,7 +29,8 @@ from directory.models import (
     Localization,
     ServiceLocation,
     ResearchGroup,
-    ReleationsFT, ParaclinicTemplateNameDepartment,
+    ReleationsFT,
+    ParaclinicTemplateNameDepartment,
 )
 from directory.utils import get_researches_details
 from laboratory.decorators import group_required

--- a/api/urls.py
+++ b/api/urls.py
@@ -140,4 +140,5 @@ urlpatterns = [
     path('update-control-param', views.update_control_param),
     path('add-control-param', views.add_control_param),
     path('update-order-param', views.update_order_param),
+    path('get-departments-with-exclude', views.get_departments_with_exclude),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -3398,5 +3398,6 @@ def get_date_medical_examination(request):
 
 @login_required
 def get_departments_with_exclude(request):
-    departments = Podrazdeleniya.get_all_departments([2])
+    request_data = json.loads(request.body)
+    departments = Podrazdeleniya.get_all_departments(request_data.get("exclude"))
     return JsonResponse({"data": departments})

--- a/api/views.py
+++ b/api/views.py
@@ -795,19 +795,19 @@ def directive_from(request):
     hospital = request.user.doctorprofile.hospital
     for dep in (
         Podrazdeleniya.objects.filter(p_type__in=(Podrazdeleniya.DEPARTMENT, Podrazdeleniya.HOSP, Podrazdeleniya.PARACLINIC, Podrazdeleniya.CASE), hospital__in=(hospital, None))
-        .prefetch_related(
+            .prefetch_related(
             Prefetch(
                 "doctorprofile_set",
                 queryset=(
                     users.DoctorProfile.objects.filter(user__groups__name__in=["Лечащий врач", "Врач параклиники"])
-                    .distinct("fio", "pk")
-                    .filter(Q(hospital=hospital) | Q(hospital__isnull=True), dismissed=False)
-                    .order_by("fio")
+                        .distinct("fio", "pk")
+                        .filter(Q(hospital=hospital) | Q(hospital__isnull=True), dismissed=False)
+                        .order_by("fio")
                 ),
             )
         )
-        .order_by("title")
-        .only("pk", "title")
+            .order_by("title")
+            .only("pk", "title")
     ):
         d = {
             "pk": dep.pk,
@@ -869,13 +869,13 @@ def statistics_tickets_get(request):
     n = 0
     for row in (
         StatisticsTicket.objects.filter(Q(doctor=request.user.doctorprofile) | Q(creator=request.user.doctorprofile))
-        .filter(
+            .filter(
             date__range=(
                 date_start,
                 date_end,
             )
         )
-        .order_by("pk")
+            .order_by("pk")
     ):
         if not row.invalid_ticket:
             n += 1
@@ -2499,8 +2499,8 @@ def org_generators_add(request):
             if is_simple_generator and key != "externalOrderNumber":
                 if (
                     directions.NumberGenerator.objects.filter(key=key)
-                    .filter(Q(start__lte=start, end__lte=end, end__gte=start) | Q(start__gte=start, start__lte=end, end__gte=end) | Q(start__gte=start, end__lte=end))
-                    .exists()
+                        .filter(Q(start__lte=start, end__lte=end, end__gte=start) | Q(start__gte=start, start__lte=end, end__gte=end) | Q(start__gte=start, end__lte=end))
+                        .exists()
                 ):
                     raise directions.GeneratorOverlap("Уже существуют генераторы, включающие указанные интервалы")
 
@@ -3394,3 +3394,9 @@ def get_date_medical_examination(request):
     request_data = json.loads(request.body)
     current_exam = MedicalExamination.get_date(request_data["card_pk"])
     return JsonResponse({"data": current_exam})
+
+
+@login_required
+def get_departments_with_exclude(request):
+    departments = Podrazdeleniya.get_all_departments([2])
+    return JsonResponse({"data": departments})

--- a/api/views.py
+++ b/api/views.py
@@ -3399,5 +3399,5 @@ def get_date_medical_examination(request):
 @login_required
 def get_departments_with_exclude(request):
     request_data = json.loads(request.body)
-    departments = Podrazdeleniya.get_all_departments(request_data.get("exclude"))
+    departments = Podrazdeleniya.get_all_departments(request_data.get("exclude_type"))
     return JsonResponse({"data": departments})

--- a/api/views.py
+++ b/api/views.py
@@ -795,19 +795,19 @@ def directive_from(request):
     hospital = request.user.doctorprofile.hospital
     for dep in (
         Podrazdeleniya.objects.filter(p_type__in=(Podrazdeleniya.DEPARTMENT, Podrazdeleniya.HOSP, Podrazdeleniya.PARACLINIC, Podrazdeleniya.CASE), hospital__in=(hospital, None))
-            .prefetch_related(
+        .prefetch_related(
             Prefetch(
                 "doctorprofile_set",
                 queryset=(
                     users.DoctorProfile.objects.filter(user__groups__name__in=["Лечащий врач", "Врач параклиники"])
-                        .distinct("fio", "pk")
-                        .filter(Q(hospital=hospital) | Q(hospital__isnull=True), dismissed=False)
-                        .order_by("fio")
+                    .distinct("fio", "pk")
+                    .filter(Q(hospital=hospital) | Q(hospital__isnull=True), dismissed=False)
+                    .order_by("fio")
                 ),
             )
         )
-            .order_by("title")
-            .only("pk", "title")
+        .order_by("title")
+        .only("pk", "title")
     ):
         d = {
             "pk": dep.pk,
@@ -869,13 +869,13 @@ def statistics_tickets_get(request):
     n = 0
     for row in (
         StatisticsTicket.objects.filter(Q(doctor=request.user.doctorprofile) | Q(creator=request.user.doctorprofile))
-            .filter(
+        .filter(
             date__range=(
                 date_start,
                 date_end,
             )
         )
-            .order_by("pk")
+        .order_by("pk")
     ):
         if not row.invalid_ticket:
             n += 1
@@ -2499,8 +2499,8 @@ def org_generators_add(request):
             if is_simple_generator and key != "externalOrderNumber":
                 if (
                     directions.NumberGenerator.objects.filter(key=key)
-                        .filter(Q(start__lte=start, end__lte=end, end__gte=start) | Q(start__gte=start, start__lte=end, end__gte=end) | Q(start__gte=start, end__lte=end))
-                        .exists()
+                    .filter(Q(start__lte=start, end__lte=end, end__gte=start) | Q(start__gte=start, start__lte=end, end__gte=end) | Q(start__gte=start, end__lte=end))
+                    .exists()
                 ):
                     raise directions.GeneratorOverlap("Уже существуют генераторы, включающие указанные интервалы")
 

--- a/directory/models.py
+++ b/directory/models.py
@@ -385,7 +385,7 @@ class Researches(models.Model):
     laboratory_duration = models.CharField(max_length=3, default="", blank=True, verbose_name="Срок выполнения")
     is_need_send_egisz = models.BooleanField(blank=True, default=False, help_text="Требуется отправка документав ЕГИСЗ")
     count_volume_material_for_tube = models.FloatField(default=0, verbose_name="Количество материала для емкости в долях", blank=True)
-    is_template_by_department = models.BooleanField(default=False, help_text="Искать шаблон заполнения по подразделению")
+    template_by_department = models.BooleanField(default=False, help_text="Искать шаблон заполнения по подразделению")
 
     @staticmethod
     def save_plan_performer(tb_data):

--- a/directory/models.py
+++ b/directory/models.py
@@ -1283,6 +1283,12 @@ class ParaclinicTemplateNameDepartment(models.Model):
     def __str__(self):
         return f"{self.template_name.title} - {self.department_id}"
 
+    @staticmethod
+    def get_departments_ids(template_name_id):
+        department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id).values_list('department_id', flat=True)
+        result = list(department_ids)
+        return result
+
 
 class AutoAdd(models.Model):
     """

--- a/directory/models.py
+++ b/directory/models.py
@@ -1284,8 +1284,8 @@ class ParaclinicTemplateNameDepartment(models.Model):
         return f"{self.template_name.title} - {self.department_id}"
 
     @staticmethod
-    def get_departments_ids(template_name_id, need_all, user_department_id):
-        if need_all:
+    def get_departments_ids(template_name_id, all_departments, user_department_id):
+        if all_departments:
             department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id).values_list('department_id', flat=True)
         else:
             department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id, department_id=user_department_id).values_list('department_id', flat=True)

--- a/directory/models.py
+++ b/directory/models.py
@@ -1284,8 +1284,11 @@ class ParaclinicTemplateNameDepartment(models.Model):
         return f"{self.template_name.title} - {self.department_id}"
 
     @staticmethod
-    def get_departments_ids(template_name_id):
-        department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id).values_list('department_id', flat=True)
+    def get_departments_ids(template_name_id, need_all, user_department_id):
+        if need_all:
+            department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id).values_list('department_id', flat=True)
+        else:
+            department_ids = ParaclinicTemplateNameDepartment.objects.filter(template_name_id=template_name_id, department_id=user_department_id).values_list('department_id', flat=True)
         result = list(department_ids)
         return result
 

--- a/directory/models.py
+++ b/directory/models.py
@@ -385,7 +385,7 @@ class Researches(models.Model):
     laboratory_duration = models.CharField(max_length=3, default="", blank=True, verbose_name="Срок выполнения")
     is_need_send_egisz = models.BooleanField(blank=True, default=False, help_text="Требуется отправка документав ЕГИСЗ")
     count_volume_material_for_tube = models.FloatField(default=0, verbose_name="Количество материала для емкости в долях", blank=True)
-    template_by_department = models.BooleanField(default=False, help_text="Искать шаблон заполнения по подразделению")
+    templates_by_department = models.BooleanField(default=False, help_text="Искать шаблоны заполнения по подразделению")
 
     @staticmethod
     def save_plan_performer(tb_data):

--- a/directory/utils.py
+++ b/directory/utils.py
@@ -44,7 +44,7 @@ def get_researches_details(pk):
         response["code"] = res.code
         response["info"] = res.paraclinic_info or ""
         response["hide"] = res.hide
-        response["templates_by_department"] = res.templates_by_department
+        response["templatesByDepartment"] = res.templates_by_department
         response["tube"] = res.microbiology_tube_id or -1
         response["site_type"] = res.site_type_id
         response["internal_code"] = res.internal_code

--- a/directory/utils.py
+++ b/directory/utils.py
@@ -44,6 +44,7 @@ def get_researches_details(pk):
         response["code"] = res.code
         response["info"] = res.paraclinic_info or ""
         response["hide"] = res.hide
+        response["templates_by_department"] = res.templates_by_department
         response["tube"] = res.microbiology_tube_id or -1
         response["site_type"] = res.site_type_id
         response["internal_code"] = res.internal_code

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -297,7 +297,7 @@ export default {
     },
     async loadDepartment() {
       await this.$store.dispatch(actions.INC_LOADING);
-      const { data } = await api('get-departments-with-exclude');
+      const { data } = await api('get-departments-with-exclude', { exclude_type: [2] });
       await this.$store.dispatch(actions.DEC_LOADING);
       this.departments.push(...data);
       this.departmentsForTemplate = data;

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -74,7 +74,7 @@
               <Treeselect
                 v-model="template_data.templateDepartmentsIds"
                 class="treeselect-nbr treeselect-wide"
-                :options="departments."
+                :options="departmentsForTemplate"
                 placeholder="Выберите подразделение"
                 :multiple="true"
               />

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -58,15 +58,26 @@
       >
         <div class="direction-data">
           <div class="results-top">
-            <div>
-              <label>
-                Название: <input
+            <div class="flex-display">
+              <div class="flex-display margin-right">
+                <label class="name-label">
+                  Название:
+                </label>
+                <input
                   v-model="template_data.title"
                   placeholder="Название"
+                  class="flex-align-center"
                   :readonly="template_data.readonly"
                 >
-              </label>
-              <strong v-if="selected_template === -1">(новый шаблон)</strong>
+                <strong v-if="selected_template === -1">(новый шаблон)</strong>
+              </div>
+              <Treeselect
+                v-model="template_data.templateDepartmentsIds"
+                class="treeselect-nbr treeselect-wide"
+                :options="departments."
+                placeholder="Выберите подразделение"
+                :multiple="true"
+              />
             </div>
             <div>
               <label>Скрыть: <input
@@ -217,6 +228,8 @@ export default {
       template_data: {},
       department: null,
       departments: [{ id: 'all', label: 'Все' }],
+      departmentsForTemplate: [],
+      forDepartments: [],
     };
   },
   watch: {
@@ -287,6 +300,7 @@ export default {
       const { data } = await api('get-departments-with-exclude');
       await this.$store.dispatch(actions.DEC_LOADING);
       this.departments.push(...data);
+      this.departmentsForTemplate = data;
     },
     select_template(pk) {
       if (pk === this.selected_template) return;
@@ -879,4 +893,16 @@ export default {
       padding: 2px 10px;
     }
   }
+.flex-display {
+  display: flex;
+}
+.name-label {
+  margin: auto 2px;
+}
+.margin-right {
+  margin-right: 5px;
+}
+.flex-align-center {
+  align-self: center;
+}
 </style>

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -223,7 +223,6 @@ export default {
   data() {
     return {
       rows: [],
-      loaded: false,
       checked: false,
       selected_template: -2,
       template_data: {},

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -283,9 +283,9 @@ export default {
       });
     },
     async loadDepartment() {
-      this.$store.dispatch(actions.INC_LOADING);
+      await this.$store.dispatch(actions.INC_LOADING);
       const { data } = await api('get-departments-with-exclude');
-      this.$store.dispatch(actions.DEC_LOADING);
+      await this.$store.dispatch(actions.DEC_LOADING);
       this.departments.push(...data);
     },
     select_template(pk) {

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -72,6 +72,7 @@
                 <strong v-if="selected_template === -1">(новый шаблон)</strong>
               </div>
               <Treeselect
+                v-if="byDepartment"
                 v-model="template_data.templateDepartmentsIds"
                 class="treeselect-nbr treeselect-wide"
                 :options="departmentsForTemplate"

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -3,7 +3,7 @@
     ref="modal"
     show-footer="true"
     white-bg="true"
-    min-width="85%"
+    min-width="95%"
     margin-top
     @close="hide_modal"
   >
@@ -278,9 +278,10 @@ export default {
       };
       this.selected_template = -1;
     },
-    load_data(selectAfter) {
-      this.loaded = false;
-      this.clear();
+    load_data(selectAfter, clear = true) {
+      if (clear) {
+        this.clear();
+      }
       let department = null;
       if (this.department !== 'all') {
         department = this.department;
@@ -293,7 +294,6 @@ export default {
         }
       }).finally(() => {
         this.$store.dispatch(actions.DEC_LOADING);
-        this.loaded = true;
       });
     },
     async loadDepartment() {
@@ -305,7 +305,6 @@ export default {
     },
     select_template(pk) {
       if (pk === this.selected_template) return;
-      this.clear();
       this.$store.dispatch(actions.INC_LOADING);
       researchesPoint.getTemplateData({ pk }).then(({ data }) => {
         this.template_data = data;
@@ -327,17 +326,16 @@ export default {
       });
     },
     save() {
-      this.loaded = false;
       this.$store.dispatch(actions.INC_LOADING);
       researchesPoint.saveFastTemplate({
         pk: this.selected_template,
         data: this.template_data,
         research_pk: this.research_pk,
       }).then(({ pk }) => {
-        this.load_data(pk);
+        this.load_data(pk, false);
+        this.$root.$emit('msg', 'ok', 'Сохранено');
       }).finally(() => {
         this.$store.dispatch(actions.DEC_LOADING);
-        this.loaded = true;
       });
     },
   },

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -9,17 +9,17 @@
   >
     <span slot="header">Настройка шаблонов быстрого ввода ({{ title }})</span>
     <div
-      v-if="loaded"
       slot="body"
       style="min-height: 200px"
       class="directions-manage"
     >
       <div class="directions-sidebar">
-        <div v-if="byDepartment">
+        <div>
           <Treeselect
             v-model="department"
             class="treeselect-nbr treeselect-wide"
             :options="departments"
+            :clearable="false"
             placeholder="Выберите подразделение"
           />
         </div>
@@ -160,13 +160,6 @@
         </div>
       </div>
     </div>
-    <div
-      v-else
-      slot="body"
-      style="line-height: 200px;text-align: center"
-    >
-      Загрузка данных...
-    </div>
     <div slot="footer">
       <div class="row">
         <div class="col-xs-8" />
@@ -223,7 +216,7 @@ export default {
       selected_template: -2,
       template_data: {},
       department: null,
-      departments: [],
+      departments: [{ id: 'all', label: 'Все' }],
     };
   },
   watch: {
@@ -239,9 +232,12 @@ export default {
         this.checked = true;
       }
     },
+    department() {
+      this.load_data();
+    },
   },
   created() {
-    this.load_data();
+    this.department = 'all';
     if (this.byDepartment) {
       this.loadDepartment();
     }
@@ -271,8 +267,12 @@ export default {
     load_data(selectAfter) {
       this.loaded = false;
       this.clear();
+      let department = null;
+      if (this.department !== 'all') {
+        department = this.department;
+      }
       this.$store.dispatch(actions.INC_LOADING);
-      researchesPoint.getFastTemplates({ pk: this.research_pk, all: true }).then(({ data }) => {
+      researchesPoint.getFastTemplates({ pk: this.research_pk, all: true, department }).then(({ data }) => {
         this.rows = data;
         if (selectAfter) {
           this.select_template(selectAfter);
@@ -286,7 +286,7 @@ export default {
       this.$store.dispatch(actions.INC_LOADING);
       const { data } = await api('get-departments-with-exclude');
       this.$store.dispatch(actions.DEC_LOADING);
-      this.departments = data;
+      this.departments.push(...data);
     },
     select_template(pk) {
       if (pk === this.selected_template) return;

--- a/l2-frontend/src/construct/FastTemplatesEditor.vue
+++ b/l2-frontend/src/construct/FastTemplatesEditor.vue
@@ -15,6 +15,14 @@
       class="directions-manage"
     >
       <div class="directions-sidebar">
+        <div v-if="byDepartment">
+          <Treeselect
+            v-model="department"
+            class="treeselect-nbr treeselect-wide"
+            :options="departments"
+            placeholder="Выберите подразделение"
+          />
+        </div>
         <div class="inner">
           <div
             v-for="d in rows"
@@ -177,14 +185,18 @@
 </template>
 
 <script lang="ts">
+import Treeselect from '@riophae/vue-treeselect';
+
 import Modal from '@/ui-cards/Modal.vue';
 import MKBField from '@/fields/MKBField.vue';
 import researchesPoint from '@/api/researches-point';
 import * as actions from '@/store/action-types';
+import '@riophae/vue-treeselect/dist/vue-treeselect.css';
+import api from '@/api';
 
 export default {
   name: 'FastTemplatesEditor',
-  components: { Modal, MKBField },
+  components: { Modal, MKBField, Treeselect },
   props: {
     research_pk: {
       type: Number,
@@ -198,6 +210,10 @@ export default {
       type: Array,
       required: true,
     },
+    byDepartment: {
+      type: Boolean,
+      required: false,
+    },
   },
   data() {
     return {
@@ -206,6 +222,8 @@ export default {
       checked: false,
       selected_template: -2,
       template_data: {},
+      department: null,
+      departments: [],
     };
   },
   watch: {
@@ -224,6 +242,9 @@ export default {
   },
   created() {
     this.load_data();
+    if (this.byDepartment) {
+      this.loadDepartment();
+    }
   },
   methods: {
     hide_modal() {
@@ -260,6 +281,12 @@ export default {
         this.$store.dispatch(actions.DEC_LOADING);
         this.loaded = true;
       });
+    },
+    async loadDepartment() {
+      this.$store.dispatch(actions.INC_LOADING);
+      const { data } = await api('get-departments-with-exclude');
+      this.$store.dispatch(actions.DEC_LOADING);
+      this.departments = data;
     },
     select_template(pk) {
       if (pk === this.selected_template) return;
@@ -341,7 +368,7 @@ export default {
     background: rgba(0, 0, 0, .04);
     border-right: 1px solid rgba(0, 0, 0, .16);
     position: relative;
-    padding-bottom: 34px;
+    padding-bottom: 36px;
     .inner {
       height: 100%;
       width: 100%;

--- a/l2-frontend/src/construct/ParaclinicResearchEditor.vue
+++ b/l2-frontend/src/construct/ParaclinicResearchEditor.vue
@@ -81,6 +81,15 @@
               {{ d.title }}
             </option>
           </select>
+          <label
+            v-if="fte"
+            class="input-group-addon"
+          >
+            <input
+              type="checkbox"
+            >
+            Шаблоны по подразделению
+          </label>
         </div>
       </div>
       <div
@@ -1207,6 +1216,7 @@ export default {
       result_current_form: 0,
       info: '',
       hide: false,
+      template_by_department: false,
       cancel_do: false,
       loaded_pk: -2,
       site_type: null,

--- a/l2-frontend/src/construct/ParaclinicResearchEditor.vue
+++ b/l2-frontend/src/construct/ParaclinicResearchEditor.vue
@@ -58,6 +58,7 @@
             </button>
           </span>
           <label
+            v-if="(ex_dep === 12 || simple) && fte && ex_dep !== 14"
             class="input-group-addon"
           >
             <input
@@ -263,6 +264,7 @@
             </button>
           </span>
           <label
+            v-if="fte"
             class="input-group-addon"
           >
             <input

--- a/l2-frontend/src/construct/ParaclinicResearchEditor.vue
+++ b/l2-frontend/src/construct/ParaclinicResearchEditor.vue
@@ -61,7 +61,7 @@
             class="input-group-addon"
           >
             <input
-              v-model="templates_by_department"
+              v-model="templatesByDepartment"
               type="checkbox"
             >
             По подразделению
@@ -266,7 +266,7 @@
             class="input-group-addon"
           >
             <input
-              v-model="templates_by_department"
+              v-model="templatesByDepartment"
               type="checkbox"
             >
             По подразделению
@@ -1225,7 +1225,7 @@ export default {
       result_current_form: 0,
       info: '',
       hide: false,
-      templates_by_department: false,
+      templatesByDepartment: false,
       cancel_do: false,
       loaded_pk: -2,
       site_type: null,
@@ -1600,6 +1600,7 @@ export default {
       this.code = '';
       this.info = '';
       this.hide = false;
+      this.templatesByDepartment = false;
       this.site_type = null;
       this.groups = [];
       this.direction_current_form = '';
@@ -1632,6 +1633,7 @@ export default {
             this.hospital_research_department_pk = data.department;
             this.info = data.info.replace(/<br\/>/g, '\n').replace(/<br>/g, '\n');
             this.hide = data.hide;
+            this.templatesByDepartment = data.templatesByDepartment;
             this.site_type = data.site_type;
             this.loaded_pk = this.pk;
             this.groups = data.groups;
@@ -1679,7 +1681,7 @@ export default {
         'is_global_direction_params',
         'code',
         'hide',
-        'templates_by_department',
+        'templatesByDepartment',
         'groups',
         'site_type',
         'internal_code',

--- a/l2-frontend/src/construct/ParaclinicResearchEditor.vue
+++ b/l2-frontend/src/construct/ParaclinicResearchEditor.vue
@@ -1112,6 +1112,7 @@
       :title="title"
       :research_pk="loaded_pk"
       :groups="groups"
+      :by-department="templatesByDepartment"
     />
     <Localizations
       v-if="show_localization"

--- a/l2-frontend/src/construct/ParaclinicResearchEditor.vue
+++ b/l2-frontend/src/construct/ParaclinicResearchEditor.vue
@@ -57,6 +57,15 @@
               Шаблоны быстрого ввода
             </button>
           </span>
+          <label
+            class="input-group-addon"
+          >
+            <input
+              v-model="templates_by_department"
+              type="checkbox"
+            >
+            По подразделению
+          </label>
         </div>
         <div
           v-if="ex_dep !== 12 && ex_dep !== 13 && ex_dep !== 14 && ex_dep !== 15"
@@ -81,15 +90,6 @@
               {{ d.title }}
             </option>
           </select>
-          <label
-            v-if="fte"
-            class="input-group-addon"
-          >
-            <input
-              type="checkbox"
-            >
-            Шаблоны по подразделению
-          </label>
         </div>
       </div>
       <div
@@ -262,6 +262,15 @@
               Шаблоны быстрого ввода
             </button>
           </span>
+          <label
+            class="input-group-addon"
+          >
+            <input
+              v-model="templates_by_department"
+              type="checkbox"
+            >
+            По подразделению
+          </label>
         </div>
       </div>
       <div
@@ -1216,7 +1225,7 @@ export default {
       result_current_form: 0,
       info: '',
       hide: false,
-      template_by_department: false,
+      templates_by_department: false,
       cancel_do: false,
       loaded_pk: -2,
       site_type: null,
@@ -1670,6 +1679,7 @@ export default {
         'is_global_direction_params',
         'code',
         'hide',
+        'templates_by_department',
         'groups',
         'site_type',
         'internal_code',

--- a/podrazdeleniya/models.py
+++ b/podrazdeleniya/models.py
@@ -76,6 +76,14 @@ class Podrazdeleniya(models.Model):  # Модель подразделений
         result = [{"id": podrazdelenie.pk, "label": podrazdelenie.title} for podrazdelenie in Podrazdeleniya.objects.filter(p_type=p_type).order_by('title')]
         return result
 
+    @staticmethod
+    def get_all_departments(exclude=None):
+        type_exclude = [0]
+        if exclude:
+            type_exclude.extend(exclude)
+        result = [{"id": podrazdelenie.pk, "label": podrazdelenie.title} for podrazdelenie in Podrazdeleniya.objects.all().exclude(p_type__in=type_exclude).order_by('title')]
+        return result
+
     def __str__(self):
         return self.title
 


### PR DESCRIPTION
## Описание изменений
* Поле у услуги - переименовал
* При загрузке шаблонов протокола и шаблонов полей в услуге - выдавать по подразделению
* Конструктор шаблонов на протокол - функционал для создания шаблонов по подразделению
* Новая группа прав 'Конструктор: Параклинические (описательные) исследования - шаблоны по подразделениям' - возможность пользователю видеть-изменять шаблоны не его подразделения