### PR TITLE
График рабочего времени - шаблоны времени v2

### DIFF
--- a/appconf/manager.py
+++ b/appconf/manager.py
@@ -217,6 +217,7 @@ class SettingManager:
             "show_cancel_button": SettingManager.get("show_cancel_button", default='true', default_type='b'),
             "forms_url": SettingManager.forms_url(),
             "l2_show_external_org_fin_sources": SettingManager.get("l2_show_external_org_fin_sources", default='', default_type='s').split(","),
+            "working_time_variants": SettingManager.get("working_time_variants", default="", default_type='s').split(","),
         }
         cache.set(k, simplejson.dumps(result), 60 * 60 * 8)
 

--- a/appconf/manager.py
+++ b/appconf/manager.py
@@ -217,7 +217,7 @@ class SettingManager:
             "show_cancel_button": SettingManager.get("show_cancel_button", default='true', default_type='b'),
             "forms_url": SettingManager.forms_url(),
             "l2_show_external_org_fin_sources": SettingManager.get("l2_show_external_org_fin_sources", default='', default_type='s').split(","),
-            "working_time_variants": SettingManager.get("working_time_variants", default="", default_type='s').split(","),
+            "working_time_variants": SettingManager.get("working_time_variants", default="", default_type='s'),
         }
         cache.set(k, simplejson.dumps(result), 60 * 60 * 8)
 

--- a/l2-frontend/src/pages/WorkingTime/DateCell.vue
+++ b/l2-frontend/src/pages/WorkingTime/DateCell.vue
@@ -24,14 +24,6 @@
       >{{ currentTime.text }}</p>
       <!-- eslint-enable -->
     </button>
-    <!--    <button-->
-    <!--      v-tippy-->
-    <!--      class="transparentButton"-->
-    <!--      title="Скопировать предыдущий"-->
-    <!--      @click="copyPrevTime"-->
-    <!--    >-->
-    <!--      <i class="fa-solid fa-copy" />-->
-    <!--    </button>-->
     <div
       id="temp"
       class="tp"
@@ -139,13 +131,6 @@ const timeValid = () => {
 };
 
 const selectedTimeOption = ref(null);
-// const timeOptions = ref([
-//   { id: 1, startWork: '08:00', endWork: '16:30' },
-//   { id: 2, startWork: '08:00', endWork: '15:48' },
-//   { id: 3, startWork: '15:48', endWork: '23:59' },
-//   { id: 4, startWork: '19:48', endWork: '21:00' },
-//   { id: 5, startWork: '14:48', endWork: '16:00' },
-// ]);
 
 const selectTime = (variantId: number, startTime: string, endTime: string) => {
   selectedTimeOption.value = variantId;
@@ -205,9 +190,6 @@ const appendCurrentTime = () => {
   selectedTimeOption.value = null;
 };
 
-// const copyPrevTime = () => {
-//   root.$emit('msg', 'ok', 'Скопировано');
-// };
 
 watch(() => props.workTime, () => {
   appendCurrentTime();

--- a/l2-frontend/src/pages/WorkingTime/DateCell.vue
+++ b/l2-frontend/src/pages/WorkingTime/DateCell.vue
@@ -38,13 +38,13 @@
     >
       <div class="tp-row">
         <div
-          v-for="option in timeOptions"
+          v-for="option in props.timeOptions"
           :key="option.id"
           class="variant"
           :class="selectedTimeOption === option.id && 'active'"
-          @click="selectTime(option.id, option.startWork, option.endWork)"
+          @click="selectTime(option.id, option.start, option.end)"
         >
-          {{ `${option.startWork}-${option.endWork}` }}
+          {{ `${option.start}-${option.end}` }}
         </div>
       </div>
       <div class="tp-row">
@@ -105,6 +105,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  timeOptions: {
+    type: Array,
+    required: true,
+  },
 });
 
 const root = getCurrentInstance().proxy.$root;
@@ -135,13 +139,13 @@ const timeValid = () => {
 };
 
 const selectedTimeOption = ref(null);
-const timeOptions = ref([
-  { id: 1, startWork: '08:00', endWork: '16:30' },
-  { id: 2, startWork: '08:00', endWork: '15:48' },
-  { id: 3, startWork: '15:48', endWork: '23:59' },
-  { id: 4, startWork: '19:48', endWork: '21:00' },
-  { id: 5, startWork: '14:48', endWork: '16:00' },
-]);
+// const timeOptions = ref([
+//   { id: 1, startWork: '08:00', endWork: '16:30' },
+//   { id: 2, startWork: '08:00', endWork: '15:48' },
+//   { id: 3, startWork: '15:48', endWork: '23:59' },
+//   { id: 4, startWork: '19:48', endWork: '21:00' },
+//   { id: 5, startWork: '14:48', endWork: '16:00' },
+// ]);
 
 const selectTime = (variantId: number, startTime: string, endTime: string) => {
   selectedTimeOption.value = variantId;

--- a/l2-frontend/src/pages/WorkingTime/DateCell.vue
+++ b/l2-frontend/src/pages/WorkingTime/DateCell.vue
@@ -190,7 +190,6 @@ const appendCurrentTime = () => {
   selectedTimeOption.value = null;
 };
 
-
 watch(() => props.workTime, () => {
   appendCurrentTime();
 }, { immediate: true });

--- a/l2-frontend/src/pages/WorkingTime/WorkingTimeTable.vue
+++ b/l2-frontend/src/pages/WorkingTime/WorkingTimeTable.vue
@@ -109,6 +109,7 @@ const props = defineProps({
 const root = getCurrentInstance().proxy.$root;
 
 const filtersFull = computed(() => !!(props.year && props.month && props.department));
+const timeOptions = computed(() => JSON.parse(store.getters.modules.working_time_variants));
 
 const search = ref('');
 
@@ -276,6 +277,7 @@ const getColumns = () => {
             employeePositionId: row.employeePositionId,
             date: column.key,
             workDayStatuses: workDayStatuses.value,
+            timeOptions: timeOptions.value,
           },
           on: { changeWorkTime },
         },


### PR DESCRIPTION
## Описание изменений
* Шаблоны времени теперь настраиваются в SettingsManager (Appconf)
Пример:
[
  { "id": 1, "start": "08:00", "end": "16:30" },
  { "id": 2, "start": "08:00", "end": "15:48" },
  { "id": 3, "start": "15:48", "end": "23:59" },
  { "id": 4, "start": "19:48", "end": "21:00" },
  { "id": 5, "start": "14:48", "end": "16:00 "}
]


* Удаление лишних элементов