### PR TITLE
График рабочего времени - исправления

### DIFF
--- a/employees/models.py
+++ b/employees/models.py
@@ -19,7 +19,7 @@ class Employee(models.Model):
     hospital = models.ForeignKey(Hospitals, on_delete=models.CASCADE, verbose_name='Медицинское учреждение')
     family = models.CharField(max_length=64, verbose_name='Фамилия')
     name = models.CharField(max_length=64, verbose_name='Имя')
-    patronymic = models.CharField(max_length=64, verbose_name='Отчество')
+    patronymic = models.CharField(max_length=64, verbose_name='Отчество', blank=True, null=True)
     is_active = models.BooleanField(default=True, verbose_name='Активен')
     created_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')
     updated_at = models.DateTimeField(auto_now=True, verbose_name='Дата обновления')

--- a/l2-frontend/src/pages/Employees/Employees.vue
+++ b/l2-frontend/src/pages/Employees/Employees.vue
@@ -259,6 +259,10 @@ const filteredEmployees = computed(() => employees.value.filter(employee => {
 
 const employeesPagination = computed(() => filteredEmployees.value.slice((page.value - 1)
   * pageSize.value, page.value * pageSize.value));
+
+watch(search, () => {
+  pageNumberChange(1);
+});
 </script>
 
 <style scoped lang="scss">

--- a/l2-frontend/src/pages/WorkingTime/WorkingTimeTable.vue
+++ b/l2-frontend/src/pages/WorkingTime/WorkingTimeTable.vue
@@ -112,7 +112,8 @@ const props = defineProps({
 const root = getCurrentInstance().proxy.$root;
 
 const filtersFull = computed(() => !!(props.year && props.month && props.department));
-const timeOptions = computed(() => JSON.parse(store.getters.modules.working_time_variants));
+const timeOptions = computed(() => (store.getters.modules.working_time_variants
+  ? JSON.parse(store.getters.modules.working_time_variants) : []));
 
 const search = ref('');
 


### PR DESCRIPTION
## Описание изменений
* Поиск в "работники" - переключение на 1ую страницу при начале поиска
* График - при отсутствии timeOptions в appconf не выдает ошибки
* Отчество у работников - не обязательное поле