### PR TITLE
Refactor request handling and UI components

### DIFF
--- a/api/requests/views.py
+++ b/api/requests/views.py
@@ -39,29 +39,49 @@ def check_hospital_access(doctor_profile, hospital_id):
 @group_required('Создание и исполнение заявок')
 def get_requests(request):
     request_data = json.loads(request.body)
-    date = request_data.get('date')
+    date_from = request_data.get('dateFrom')
+    date_to = request_data.get('dateTo')
     search_type = request_data.get('searchType', 'all')
     card_id = request_data.get('cardId')
+    only_mine = request_data.get('onlyMine', False)
+    offset = request_data.get('offset', 0)
+    limit = request_data.get('limit', 50)
 
     directions = (
-        Napravleniya.objects.filter(is_request=True, doc=request.user.doctorprofile)
-        .select_related("client__individual")
+        Napravleniya.objects.filter(is_request=True)
+        .select_related("client__individual", "doc")
         .prefetch_related('issledovaniya_set__research')
         .prefetch_related('napravleniyafiles_set')
         .order_by("-data_sozdaniya")
     )
 
+    if search_type in ('search', 'card'):
+        hospital_id = request.user.doctorprofile.hospital_id
+        if hospital_id:
+            directions = directions.filter(hospital_id=hospital_id)
+        else:
+            directions = directions.filter(doc=request.user.doctorprofile)
+        if only_mine:
+            directions = directions.filter(doc=request.user.doctorprofile)
+    else:
+        directions = directions.filter(doc=request.user.doctorprofile)
+
     if search_type == 'card' and card_id:
         directions = directions.filter(client_id=card_id)
 
-    if date:
+    if date_from and date_to:
         try:
-            search_date = datetime.strptime(date, '%d.%m.%Y').date()
-            directions = directions.filter(data_sozdaniya__date=search_date)
+            search_date_from = datetime.strptime(date_from, '%d.%m.%Y').date()
+            search_date_to = datetime.strptime(date_to, '%d.%m.%Y').date()
+            directions = directions.filter(
+                data_sozdaniya__date__gte=search_date_from,
+                data_sozdaniya__date__lte=search_date_to,
+            )
         except ValueError:
             pass
 
-    directions_list = list(directions)
+    total_count = directions.count()
+    directions_list = list(directions[offset : offset + limit])
 
     direction_ids = [d.pk for d in directions_list]
     equipment_receives = set(EquipmentReceive.objects.filter(napravleniye_id__in=direction_ids).values_list('napravleniye_id', flat=True))
@@ -91,14 +111,16 @@ def get_requests(request):
                 "patient": direction.client.individual.fio(),
                 "datetime": strfdatetime(direction.data_sozdaniya, '%d.%m.%Y %H:%M'),
                 "hasImage": has_image,
+                "hasResult": direction.total_confirmed,
                 "cardId": direction.client.pk,
                 "files": files,
                 "researchTitle": research_titles[0] if research_titles else "",
                 "isCito": direction.is_cito,
+                "creator": direction.doc.get_fio() if direction.doc and direction.doc != request.user.doctorprofile else "",
             }
         )
 
-    return JsonResponse({"rows": rows})
+    return JsonResponse({"rows": rows, "total": total_count, "hasMore": offset + limit < total_count})
 
 
 @login_required
@@ -453,7 +475,7 @@ def get_request_params(request):
         return JsonResponse({"success": False, "message": str(e)})
 
     try:
-        direction = Napravleniya.objects.select_related('client__individual', 'doc').get(pk=request_id, is_request=True)
+        direction = Napravleniya.objects.select_related('client__individual', 'doc').prefetch_related('napravleniyafiles_set').get(pk=request_id, is_request=True)
     except Napravleniya.DoesNotExist:
         return JsonResponse({"success": False, "message": "Заявка не найдена"})
 
@@ -462,28 +484,50 @@ def get_request_params(request):
 
     params = {}
 
-    if direction.fact_research_date:
-        params["Дата исследования"] = strfdatetime(direction.fact_research_date, '%d.%m.%Y')
+    if direction.doc:
+        params["creator"] = direction.doc.get_fio()
 
-    if direction.contrast_amount:
-        params["Количество контраста"] = direction.contrast_amount
+    params["createdAt"] = strfdatetime(direction.data_sozdaniya, '%d.%m.%Y %H:%M')
+
+    if direction.fact_research_date:
+        params["researchDate"] = strfdatetime(direction.fact_research_date, '%d.%m.%Y')
 
     if direction.dose:
-        params["Доза"] = direction.dose
+        params["dose"] = direction.dose
+
+    if direction.contrast_amount:
+        params["contrastAmount"] = direction.contrast_amount
+
+    params["isCito"] = direction.is_cito
+
+    equipment_receive = EquipmentReceive.objects.filter(napravleniye_id=direction.pk).first()
+    params["hasImage"] = equipment_receive is not None
+    if equipment_receive:
+        params["imageId"] = equipment_receive.pk
+        params["imageData"] = {
+            "id": equipment_receive.pk,
+            "studyInstanceUidTag": equipment_receive.study_instance_uid_tag,
+            "family": equipment_receive.family,
+            "name": equipment_receive.name,
+            "patronymic": equipment_receive.patronymic,
+            "birthday": equipment_receive.birthday.strftime('%d.%m.%Y') if equipment_receive.birthday else None,
+            "sex": equipment_receive.sex,
+            "patientId": equipment_receive.tag_patient_id,
+            "orderId": equipment_receive.order_id,
+            "createdAt": strfdatetime(equipment_receive.created_at),
+            "equipmentTitle": equipment_receive.equipment_model.title if equipment_receive.equipment_model else None,
+        }
 
     if direction.anamnesis:
-        params["Анамнез"] = direction.anamnesis
+        params["anamnesis"] = direction.anamnesis
 
     if direction.direction_comment:
-        params["Комментарий"] = direction.direction_comment
+        params["comment"] = direction.direction_comment
 
-    if direction.is_cito:
-        params["Статус"] = "CITO"
-
-    params["Создана"] = strfdatetime(direction.data_sozdaniya, '%d.%m.%Y %H:%M')
-
-    if direction.doc:
-        params["Врач"] = direction.doc.get_fio()
+    files = []
+    for file_obj in direction.napravleniyafiles_set.all():
+        files.append({"name": file_obj.uploaded_file.name.split('/')[-1] if file_obj.uploaded_file else 'Файл', "url": file_obj.uploaded_file.url if file_obj.uploaded_file else ''})
+    params["files"] = files
 
     return JsonResponse({"success": True, "params": params})
 

--- a/l2-frontend/src/components/Collapse.vue
+++ b/l2-frontend/src/components/Collapse.vue
@@ -3,7 +3,7 @@
     <div
       ref="content"
       :class="{ [$style.collapsed]: !isExpanded && isCollapsible }"
-      :style="{ 'max-height': !isExpanded && isCollapsible ? maxHeight : 'none' }"
+      :style="contentStyle"
     >
       <slot />
     </div>
@@ -19,6 +19,7 @@
 
 <script setup lang="ts">
 import {
+  computed,
   nextTick,
   onMounted,
   onUpdated,
@@ -31,12 +32,27 @@ const props = defineProps({
     type: String,
     default: '200px',
   },
+  bgColor: {
+    type: String,
+    default: 'white',
+  },
 });
 
 const content = ref<HTMLElement | null>(null);
 const isCollapsible = ref(false);
 const isExpanded = ref(false);
 const slots = useSlots();
+
+const contentStyle = computed(() => {
+  const style: Record<string, string> = {};
+  if (!isExpanded.value && isCollapsible.value) {
+    style['max-height'] = props.maxHeight;
+    style['--collapse-bg'] = props.bgColor;
+  } else {
+    style['max-height'] = 'none';
+  }
+  return style;
+});
 
 const checkHeight = async () => {
   await nextTick();
@@ -75,7 +91,7 @@ onUpdated(() => {
     left: 0;
     right: 0;
     height: 50px;
-    background: linear-gradient(to bottom, transparent, white);
+    background: linear-gradient(to bottom, transparent, var(--collapse-bg, white));
     pointer-events: none;
   }
 }

--- a/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
+++ b/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
@@ -37,7 +37,7 @@
           </div>
         </div>
         <label
-          v-if="searchMode === 'card' || searchMode === 'search'"
+          v-if="searchMode === 'card'"
           class="only-mine-filter"
         >
           <input
@@ -49,7 +49,7 @@
       </div>
       <div
         class="directions"
-        :class="{ 'with-filter': searchMode === 'card' || searchMode === 'search' }"
+        :class="{ 'with-filter': searchMode === 'card' }"
       >
         <div
           ref="listContainer"
@@ -550,7 +550,8 @@ const refreshNewItems = async () => {
       }
     }
   } catch (error) {
-    console.error('Auto-refresh error:', error);
+    // eslint-disable-next-line no-console
+    console.error(error);
   } finally {
     isRefreshing.value = false;
   }

--- a/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
+++ b/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
@@ -106,10 +106,10 @@
             </div>
             <div class="research-row">
               <div class="row">
-                <div class="col-xs-5">
+                <div class="col-xs-7">
                   {{ formatDateTime(item.datetime) }}
                 </div>
-                <div class="col-xs-7 text-right">
+                <div class="col-xs-5 text-right">
                   <span
                     class="image-status"
                     :class="item.hasImage ? 'image-status--yes' : 'image-status--no'"

--- a/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
+++ b/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
@@ -21,8 +21,7 @@
               class="dropdown-menu min-width-160 margin-top-1"
             >
               <li
-                v-for="row in SEARCH_MODES"
-                v-if="row.id !== searchMode"
+                v-for="row in availableSearchModes"
                 :key="row.id"
               >
                 <a
@@ -33,19 +32,44 @@
               </li>
             </ul>
           </span>
-          <DateFieldNav
-            :def="selectedDate"
-            :val.sync="selectedDate"
-            w="100px"
-            light
-          />
+          <div>
+            <DateRange v-model="dateRange" />
+          </div>
         </div>
+        <label
+          v-if="searchMode === 'card' || searchMode === 'search'"
+          class="only-mine-filter"
+        >
+          <input
+            v-model="onlyMine"
+            type="checkbox"
+          >
+          Только созданные мной
+        </label>
       </div>
-      <div class="directions">
+      <div
+        class="directions"
+        :class="{ 'with-filter': searchMode === 'card' || searchMode === 'search' }"
+      >
         <div
+          ref="listContainer"
           class="inner"
           :class="{ 'with-bottom-header': isSelectionMode }"
+          @scroll="onListScroll"
         >
+          <div
+            v-if="showNewItemsBanner"
+            class="new-items-banner"
+          >
+            <span>Есть новые заявки</span>
+            <button
+              class="new-items-button"
+              type="button"
+              @click="showPendingItems"
+            >
+              Показать
+            </button>
+          </div>
           <div
             v-for="item in requests"
             :key="item.id"
@@ -71,13 +95,21 @@
                 v-if="item.isCito"
                 class="cito-badge"
               >CITO</span>
+              <button
+                v-if="item.hasResult"
+                class="print-result-btn"
+                title="Печать результата"
+                @click.stop="printResult(item.id)"
+              >
+                <i class="fa fa-print" /> Результат
+              </button>
             </div>
             <div class="research-row">
               <div class="row">
-                <div class="col-xs-7">
-                  {{ item.datetime }}
+                <div class="col-xs-5">
+                  {{ formatDateTime(item.datetime) }}
                 </div>
-                <div class="col-xs-5 text-right">
+                <div class="col-xs-7 text-right">
                   <span
                     class="image-status"
                     :class="item.hasImage ? 'image-status--yes' : 'image-status--no'"
@@ -86,6 +118,13 @@
                   </span>
                 </div>
               </div>
+            </div>
+            <div
+              v-if="item.creator"
+              class="creator-row"
+            >
+              <i class="fa fa-user-md" />
+              {{ item.creator }}
             </div>
             <div
               v-if="item.files && item.files.length > 0"
@@ -112,6 +151,18 @@
             class="text-center margin-5"
           >
             Нет данных
+          </div>
+          <div
+            ref="loadMoreTrigger"
+            class="load-more-trigger"
+          >
+            <div
+              v-if="isLoadingMore"
+              class="loading-more"
+            >
+              <i class="fa fa-spinner fa-spin" />
+              Загрузка...
+            </div>
           </div>
         </div>
         <div
@@ -331,8 +382,9 @@ import {
 import moment from 'moment';
 
 import api from '@/api';
-import DateFieldNav from '@/fields/DateFieldNav.vue';
+import DateRange from '@/ui-cards/DateRange.vue';
 import useNotify from '@/hooks/useNotify';
+import usePrint from '@/hooks/usePrint';
 import Modal from '@/ui-cards/Modal.vue';
 
 const props = defineProps<{
@@ -340,20 +392,29 @@ const props = defineProps<{
   highlightedRequestId?: number | string | null;
 }>();
 const notify = useNotify();
+const { printResults } = usePrint();
+
+const printResult = (id: number) => {
+  printResults([id]);
+};
 
 const emit = defineEmits(['request-selected', 'cancel-selection', 'request-hover']);
 
 const SEARCH_MODES = [
-  { id: 'all', title: 'Все заявки' },
+  { id: 'all', title: 'Созданные' },
   { id: 'card', title: 'Пациент' },
+  { id: 'search', title: 'Организация' },
 ];
 
 const SEARCH_MODES_MAP = new Map(SEARCH_MODES.map((m) => [m.id, m.title]));
 
 const searchMode = ref(SEARCH_MODES[0].id);
-const selectedDate = ref(moment().format('DD.MM.YYYY'));
+const availableSearchModes = computed(() => SEARCH_MODES.filter((mode) => mode.id !== searchMode.value));
+const dateRange = ref([moment().format('DD.MM.YYYY'), moment().format('DD.MM.YYYY')]);
+const isMultipleDays = computed(() => dateRange.value[0] !== dateRange.value[1]);
 const showModes = ref(false);
 const isLoading = ref(false);
+const onlyMine = ref(false);
 const isSelectionMode = ref(false);
 const currentImageForLink = ref<any>(null);
 const showRequestDetailsModal = ref(false);
@@ -363,6 +424,13 @@ const isLoadingDetails = ref(false);
 const selectMode = (id: string) => {
   searchMode.value = id;
   showModes.value = false;
+};
+
+const formatDateTime = (datetime: string) => {
+  if (isMultipleDays.value) {
+    return datetime;
+  }
+  return datetime.split(' ')[1] || datetime;
 };
 
 type File = {
@@ -376,15 +444,25 @@ type Request = {
   patient: string;
   datetime: string;
   hasImage: boolean;
+  hasResult: boolean;
   cardId: number;
   files: File[];
   researchTitle: string;
   isCito: boolean;
+  creator?: string;
 };
 
 let autoRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+const PAGE_SIZE = 10;
 
 const requests = ref<Request[]>([]);
+const hasMore = ref(false);
+const currentOffset = ref(0);
+const isLoadingMore = ref(false);
+const isRefreshing = ref(false);
+const listContainer = ref<HTMLElement | null>(null);
+const isAtTop = ref(true);
+const pendingNewItems = ref(false);
 
 const actualCardId = computed(() => {
   if (searchMode.value === 'card' && props.cardId && props.cardId > 0) {
@@ -393,15 +471,24 @@ const actualCardId = computed(() => {
   return null;
 });
 
+const existingIds = computed(() => new Set(requests.value.map(r => r.id)));
+
 const getRequests = async () => {
+  currentOffset.value = 0;
   isLoading.value = true;
   try {
-    const { rows } = await api('requests/list', {
-      date: selectedDate.value,
+    const params: Record<string, any> = {
       searchType: searchMode.value,
       cardId: actualCardId.value,
-    });
+      offset: 0,
+      limit: PAGE_SIZE,
+      onlyMine: onlyMine.value,
+    };
+    [params.dateFrom, params.dateTo] = dateRange.value;
+    const { rows, hasMore: more } = await api('requests/list', params);
     requests.value = rows;
+    hasMore.value = more;
+    currentOffset.value = rows.length;
   } catch (error) {
     notify.error('Ошибка при получении заявок');
   } finally {
@@ -409,15 +496,99 @@ const getRequests = async () => {
   }
 };
 
-watch(actualCardId, (newCardId, oldCardId) => {
-  if (searchMode.value === 'card' && newCardId !== oldCardId && newCardId) {
-    selectedDate.value = moment().format('DD.MM.YYYY');
+const loadMore = async () => {
+  if (!hasMore.value || isLoadingMore.value || isLoading.value || isRefreshing.value) return;
+  isLoadingMore.value = true;
+  try {
+    const params: Record<string, any> = {
+      searchType: searchMode.value,
+      cardId: actualCardId.value,
+      offset: currentOffset.value,
+      limit: PAGE_SIZE,
+      onlyMine: onlyMine.value,
+    };
+    [params.dateFrom, params.dateTo] = dateRange.value;
+    const { rows, hasMore: more } = await api('requests/list', params);
+    const newRows = rows.filter((r: Request) => !existingIds.value.has(r.id));
+    requests.value = [...requests.value, ...newRows];
+    hasMore.value = more;
+    currentOffset.value += rows.length;
+  } catch (error) {
+    notify.error('Ошибка при загрузке');
+  } finally {
+    isLoadingMore.value = false;
   }
-});
+};
 
-watch([selectedDate, searchMode, actualCardId], async () => {
+const refreshNewItems = async () => {
+  if (isLoading.value || isLoadingMore.value || isRefreshing.value) return;
+  isRefreshing.value = true;
+  try {
+    const params: Record<string, any> = {
+      searchType: searchMode.value,
+      cardId: actualCardId.value,
+      offset: 0,
+      limit: PAGE_SIZE,
+      onlyMine: onlyMine.value,
+    };
+    [params.dateFrom, params.dateTo] = dateRange.value;
+    const { rows } = await api('requests/list', params);
+    const newRows = rows.filter((r: Request) => !existingIds.value.has(r.id));
+    if (newRows.length > 0) {
+      requests.value = [...newRows, ...requests.value];
+      currentOffset.value += newRows.length;
+    }
+    const existingIdsSet = existingIds.value;
+    for (const row of rows) {
+      if (existingIdsSet.has(row.id)) {
+        const existing = requests.value.find(r => r.id === row.id);
+        if (existing) {
+          existing.hasImage = row.hasImage;
+          existing.hasResult = row.hasResult;
+          existing.files = row.files;
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Auto-refresh error:', error);
+  } finally {
+    isRefreshing.value = false;
+  }
+};
+
+watch([searchMode, actualCardId, dateRange, onlyMine], async () => {
   await getRequests();
-}, { immediate: true });
+}, { immediate: true, deep: true });
+
+const showNewItemsBanner = computed(() => pendingNewItems.value && !isAtTop.value);
+
+const onListScroll = () => {
+  if (!listContainer.value) return;
+  isAtTop.value = listContainer.value.scrollTop <= 50;
+  if (isAtTop.value && pendingNewItems.value) {
+    pendingNewItems.value = false;
+    refreshNewItems();
+  }
+};
+
+const handleNewRequestCreated = async () => {
+  if (listContainer.value) {
+    isAtTop.value = listContainer.value.scrollTop <= 50;
+  }
+  if (isAtTop.value) {
+    await refreshNewItems();
+  } else {
+    pendingNewItems.value = true;
+  }
+};
+
+const showPendingItems = async () => {
+  pendingNewItems.value = false;
+  if (listContainer.value) {
+    listContainer.value.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+  await refreshNewItems();
+};
 
 const updateRequestImageStatus = (requestId: number | string, hasImage: boolean) => {
   const request = requests.value.find(r => r.id.toString() === requestId.toString());
@@ -504,8 +675,11 @@ const startAutoRefresh = () => {
   }
   autoRefreshTimer = setTimeout(async () => {
     try {
-      if (!isSelectionMode.value && !isLoading.value && selectedDate.value === moment().format('DD.MM.YYYY')) {
-        await getRequests();
+      const today = moment().format('DD.MM.YYYY');
+      const includestoday = dateRange.value[1] === today;
+      const canRefresh = !isSelectionMode.value && !isLoading.value && includestoday;
+      if (canRefresh) {
+        await refreshNewItems();
       }
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -522,12 +696,35 @@ const stopAutoRefresh = () => {
   }
 };
 
+const loadMoreTrigger = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | null = null;
+
+watch(loadMoreTrigger, (el) => {
+  if (observer && el) {
+    observer.observe(el);
+  }
+});
+
 onMounted(() => {
   startAutoRefresh();
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries[0].isIntersecting) {
+        loadMore();
+      }
+    },
+    { threshold: 0.1 },
+  );
+  if (loadMoreTrigger.value) {
+    observer.observe(loadMoreTrigger.value);
+  }
 });
 
 onUnmounted(() => {
   stopAutoRefresh();
+  if (observer) {
+    observer.disconnect();
+  }
 });
 
 defineExpose({
@@ -536,6 +733,7 @@ defineExpose({
   exitSelectionMode,
   currentImageForLink,
   refreshRequests,
+  handleNewRequestCreated,
 });
 </script>
 
@@ -557,9 +755,30 @@ defineExpose({
     border-bottom: 1px solid #b1b1b1;
   }
 }
+.only-mine-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: #555;
+  cursor: pointer;
+  background: #f5f5f5;
+  border-top: 1px solid #ddd;
+
+  input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+  }
+
+  &:hover {
+    background: #eee;
+  }
+}
 .input-group {
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 .input-group-btn {
   position: relative;
@@ -638,6 +857,10 @@ defineExpose({
   bottom: 0;
   display: flex;
   flex-direction: column;
+
+  &.with-filter {
+    top: 60px;
+  }
 }
 
 .directions .inner {
@@ -646,6 +869,39 @@ defineExpose({
   overflow-x: hidden;
   padding-bottom: 110px;
   flex: 1;
+}
+
+.new-items-banner {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 4px;
+  padding: 6px 10px;
+  margin: 8px;
+  color: #856404;
+  font-size: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.new-items-button {
+  background: transparent;
+  border: none;
+  color: #856404;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.new-items-button:hover {
+  background: rgba(133, 100, 4, 0.1);
 }
 
 .direction {
@@ -668,8 +924,31 @@ defineExpose({
   margin-top: 2px;
   margin-bottom: 2px;
 }
+.print-result-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  background: #049372;
+  border: none;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #037a5a;
+  }
+
+  i {
+    font-size: 10px;
+  }
+}
 .image-status {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
 }
 .image-status--yes {
@@ -677,6 +956,33 @@ defineExpose({
 }
 .image-status--no {
   color: #888;
+}
+.creator-row {
+  font-size: 11px;
+  color: #666;
+  margin-top: 3px;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 3px;
+
+  i {
+    margin-right: 4px;
+    color: #049372;
+  }
+}
+.load-more-trigger {
+  min-height: 20px;
+  padding: 5px;
+}
+.loading-more {
+  text-align: center;
+  color: #888;
+  font-size: 12px;
+  padding: 10px;
+
+  i {
+    margin-right: 5px;
+  }
 }
 .text-center {
   color: #aaa;
@@ -841,6 +1147,7 @@ defineExpose({
   font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-clamp: 2;
   -webkit-line-clamp: 2;
   max-height: 40px;
   display: -webkit-box;

--- a/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
+++ b/l2-frontend/src/pages/RequestCreation/RequestHistory.vue
@@ -401,7 +401,7 @@ const printResult = (id: number) => {
 const emit = defineEmits(['request-selected', 'cancel-selection', 'request-hover']);
 
 const SEARCH_MODES = [
-  { id: 'all', title: 'Созданные' },
+  { id: 'all', title: 'Мои заявки' },
   { id: 'card', title: 'Пациент' },
   { id: 'search', title: 'Организация' },
 ];
@@ -411,6 +411,7 @@ const SEARCH_MODES_MAP = new Map(SEARCH_MODES.map((m) => [m.id, m.title]));
 const searchMode = ref(SEARCH_MODES[0].id);
 const availableSearchModes = computed(() => SEARCH_MODES.filter((mode) => mode.id !== searchMode.value));
 const dateRange = ref([moment().format('DD.MM.YYYY'), moment().format('DD.MM.YYYY')]);
+const dateRangeKey = computed(() => dateRange.value.join('|'));
 const isMultipleDays = computed(() => dateRange.value[0] !== dateRange.value[1]);
 const showModes = ref(false);
 const isLoading = ref(false);
@@ -463,6 +464,14 @@ const isRefreshing = ref(false);
 const listContainer = ref<HTMLElement | null>(null);
 const isAtTop = ref(true);
 const pendingNewItems = ref(false);
+
+const scrollListToTop = (smooth = false) => {
+  if (!listContainer.value) return;
+  listContainer.value.scrollTo({
+    top: 0,
+    behavior: smooth ? 'smooth' : 'auto',
+  });
+};
 
 const actualCardId = computed(() => {
   if (searchMode.value === 'card' && props.cardId && props.cardId > 0) {
@@ -560,6 +569,16 @@ const refreshNewItems = async () => {
 watch([searchMode, actualCardId, dateRange, onlyMine], async () => {
   await getRequests();
 }, { immediate: true, deep: true });
+
+watch(searchMode, (newMode, prevMode) => {
+  if (!prevMode) return;
+  scrollListToTop();
+});
+
+watch(dateRangeKey, (newKey, prevKey) => {
+  if (!prevKey || newKey === prevKey) return;
+  scrollListToTop();
+});
 
 const showNewItemsBanner = computed(() => pendingNewItems.value && !isAtTop.value);
 

--- a/l2-frontend/src/pages/RequestCreation/index.vue
+++ b/l2-frontend/src/pages/RequestCreation/index.vue
@@ -29,7 +29,8 @@
               <template #bottom>
                 <RequestFields
                   v-if="cardId && cardId !== -1 && research && research !== -1"
-                  v-model="requestFields"
+                  :value="requestFields"
+                  @input="onRequestFieldsInput"
                   @create:request="createRequest"
                 />
               </template>
@@ -117,7 +118,13 @@ const defaultRequestFields = () => ({
   files: [] as any[],
 });
 
-const requestFields = ref(defaultRequestFields());
+type RequestFieldsValue = ReturnType<typeof defaultRequestFields>;
+
+const requestFields = ref<RequestFieldsValue>(defaultRequestFields());
+
+const onRequestFieldsInput = (value: RequestFieldsValue) => {
+  requestFields.value = value;
+};
 
 async function createRequest() {
   loader.inc();
@@ -138,7 +145,9 @@ async function createRequest() {
       notify.ok(message || 'Заявка успешно создана');
       requestFields.value = defaultRequestFields();
 
-      if (requestHistoryRef.value?.refreshRequests) {
+      if (requestHistoryRef.value?.handleNewRequestCreated) {
+        await requestHistoryRef.value.handleNewRequestCreated();
+      } else if (requestHistoryRef.value?.refreshRequests) {
         await requestHistoryRef.value.refreshRequests();
       }
     }
@@ -181,11 +190,8 @@ const onRequestSelectedForLink = (request: any) => {
 };
 
 const onCancelSelection = () => {
-  if (requestHistoryRef.value?.exitSelectionMode) {
-    requestHistoryRef.value.exitSelectionMode();
-    isSelectionMode.value = false;
-    currentImageForLink.value = null;
-  }
+  isSelectionMode.value = false;
+  currentImageForLink.value = null;
 };
 
 const onRequestHover = (request: any) => {

--- a/l2-frontend/src/pages/RequestsFill/index.vue
+++ b/l2-frontend/src/pages/RequestsFill/index.vue
@@ -167,9 +167,247 @@
           :key="selectedRequest.id"
           :direction-id-to-open="selectedRequest.id"
           forced-results-top
-        />
+        >
+          <template #before-researches>
+            <div class="request-info-block">
+              <div class="request-info-title">
+                <span>Информация о заявке</span>
+              </div>
+              <div
+                v-if="requestParams"
+                class="request-info-content"
+              >
+                <div class="info-grid">
+                  <div
+                    v-if="requestParams.creator"
+                    class="info-row"
+                  >
+                    <span class="info-label">Создал</span>
+                    <span class="info-value">{{ requestParams.creator }}</span>
+                  </div>
+                  <div
+                    v-if="requestParams.createdAt"
+                    class="info-row"
+                  >
+                    <span class="info-label">Создана</span>
+                    <span class="info-value">{{ requestParams.createdAt }}</span>
+                  </div>
+                  <div
+                    v-if="requestParams.researchDate"
+                    class="info-row"
+                  >
+                    <span class="info-label">Дата исследования</span>
+                    <span class="info-value">{{ requestParams.researchDate }}</span>
+                  </div>
+                  <div
+                    v-if="requestParams.dose"
+                    class="info-row"
+                  >
+                    <span class="info-label">Доза</span>
+                    <span class="info-value">{{ requestParams.dose }} мЗв</span>
+                  </div>
+                  <div
+                    v-if="requestParams.contrastAmount"
+                    class="info-row"
+                  >
+                    <span class="info-label">Объём контраста</span>
+                    <span class="info-value">{{ requestParams.contrastAmount }} мл</span>
+                  </div>
+                  <div class="info-row">
+                    <span class="info-label">Срочность</span>
+                    <span class="info-value">
+                      <span
+                        v-if="requestParams.isCito"
+                        class="cito-badge"
+                      >CITO</span>
+                      <template v-else>Обычная</template>
+                    </span>
+                  </div>
+                  <div class="info-row">
+                    <span class="info-label">Изображение</span>
+                    <span class="info-value">
+                      <template v-if="requestParams.hasImage">
+                        Привязано
+                        <a
+                          class="a-under"
+                          href="#"
+                          @click.prevent="showImageModal = true"
+                        ><i class="fa fa-info-circle" /></a>
+                      </template>
+                      <template v-else>
+                        Нет
+                      </template>
+                    </span>
+                  </div>
+                  <div
+                    v-if="requestParams.files && requestParams.files.length > 0"
+                    class="info-row"
+                  >
+                    <span class="info-label">Файлы</span>
+                    <span class="info-value">
+                      <a
+                        v-for="file in requestParams.files"
+                        :key="file.url"
+                        :href="file.url"
+                        target="_blank"
+                        class="a-under"
+                      >{{ file.name }}</a>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  v-if="requestParams.anamnesis"
+                  class="info-block"
+                >
+                  <div class="info-block-label">
+                    Анамнез
+                  </div>
+                  <Collapse
+                    max-height="60px"
+                    bg-color="#f9f9f9"
+                  >
+                    <div
+                      class="info-block-text"
+                      v-text="requestParams.anamnesis"
+                    />
+                  </Collapse>
+                </div>
+                <div
+                  v-if="requestParams.comment"
+                  class="info-block"
+                >
+                  <div class="info-block-label">
+                    Комментарий
+                  </div>
+                  <Collapse
+                    max-height="60px"
+                    bg-color="#f9f9f9"
+                  >
+                    <div
+                      class="info-block-text"
+                      v-text="requestParams.comment"
+                    />
+                  </Collapse>
+                </div>
+              </div>
+            </div>
+          </template>
+        </ResultsParaclinic>
       </template>
     </TwoSidedLayout>
+    <Modal
+      v-if="showImageModal && requestParams?.imageData"
+      show-footer="true"
+      white-bg="true"
+      max-width="700px"
+      margin-left-right="auto"
+      @close="showImageModal = false"
+    >
+      <span slot="header">Детали изображения #{{ requestParams.imageData.id }}</span>
+      <div
+        slot="body"
+        class="image-modal-body"
+      >
+        <div class="details-section">
+          <div class="section-title">
+            Данные пациента
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Фамилия:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.family }"
+            >{{ requestParams.imageData.family || '(не указана)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Имя:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.name }"
+            >{{ requestParams.imageData.name || '(не указано)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Отчество:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.patronymic }"
+            >{{ requestParams.imageData.patronymic || '(не указано)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Дата рождения:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.birthday }"
+            >{{ requestParams.imageData.birthday || '(не указана)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Пол:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.sex }"
+            >{{ requestParams.imageData.sex || '(не указан)' }}</span>
+          </div>
+        </div>
+
+        <div class="details-section">
+          <div class="section-title">
+            Идентификаторы
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">ID пациента:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.patientId }"
+            >{{ requestParams.imageData.patientId || '(отсутствует)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">ID заказа:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.orderId }"
+            >{{ requestParams.imageData.orderId || '(отсутствует)' }}</span>
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Study Instance UID:</span>
+            <span
+              class="detail-value small-text"
+              :class="{ 'empty-value': !requestParams.imageData.studyInstanceUidTag }"
+            >{{ requestParams.imageData.studyInstanceUidTag || '(отсутствует)' }}</span>
+          </div>
+        </div>
+
+        <div class="details-section">
+          <div class="section-title">
+            Оборудование
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Название:</span>
+            <span
+              class="detail-value"
+              :class="{ 'empty-value': !requestParams.imageData.equipmentTitle }"
+            >{{ requestParams.imageData.equipmentTitle || '(не определено)' }}</span>
+          </div>
+        </div>
+
+        <div class="details-section">
+          <div class="section-title">
+            Даты
+          </div>
+          <div class="detail-row">
+            <span class="detail-label">Создано:</span>
+            <span class="detail-value">{{ requestParams.imageData.createdAt }}</span>
+          </div>
+        </div>
+      </div>
+      <div slot="footer">
+        <button
+          class="btn btn-blue-nb"
+          @click="showImageModal = false"
+        >
+          Закрыть
+        </button>
+      </div>
+    </Modal>
   </PageInnerLayout>
 </template>
 
@@ -185,6 +423,7 @@ import moment from 'moment';
 import Treeselect from '@riophae/vue-treeselect';
 import '@riophae/vue-treeselect/dist/vue-treeselect.css';
 
+import Modal from '@/ui-cards/Modal.vue';
 import ResultsParaclinic from '@/pages/ResultsParaclinic.vue';
 import PageInnerLayout from '@/layouts/PageInnerLayout.vue';
 import TwoSidedLayout from '@/layouts/TwoSidedLayout.vue';
@@ -195,6 +434,7 @@ import directionsPoint from '@/api/directions-point';
 import useLoader from '@/hooks/useLoader';
 import useOn from '@/hooks/useOn';
 import useNotify from '@/hooks/useNotify';
+import Collapse from '@/components/Collapse.vue';
 
 import RequestCard, { type Request } from './RequestCard.vue';
 
@@ -218,6 +458,7 @@ const requestParams = ref<any>(null);
 const numberToSearch = ref<string>('');
 const isSearchMode = ref(false);
 const patientQuery = ref<string>('');
+const showImageModal = ref(false);
 let refreshInterval: any = null;
 
 const loader = useLoader();
@@ -291,6 +532,7 @@ const loadAllRequests = async () => {
 useOn('change-document-state', loadAllRequests);
 useOn('close-results-paraclinic', () => {
   selectedRequest.value = null;
+  requestParams.value = null;
 });
 
 const startAutoRefresh = () => {
@@ -354,6 +596,7 @@ const loadFormData = async (requestId: number) => {
 
 const handleCardClick = (request: Request) => {
   selectedRequest.value = request;
+  showImageModal.value = false;
   loadFormData(request.id);
   loadRequestParams(request.id);
 };
@@ -379,6 +622,7 @@ watch(date, () => {
 
 watch(selectedHospitalId, () => {
   selectedRequest.value = null;
+  requestParams.value = null;
   loadAllRequests();
 });
 
@@ -677,6 +921,148 @@ onBeforeUnmount(() => {
   button {
     flex: 3 94px;
     width: 94px;
+  }
+}
+
+.request-info-block {
+  margin-bottom: 10px;
+}
+
+.request-info-title {
+  position: sticky;
+  top: 0;
+  background-color: #ddd;
+  padding: 5px;
+  font-weight: bold;
+  z-index: 4;
+}
+
+.request-info-content {
+  padding: 10px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-top: none;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 20px;
+}
+
+.info-row {
+  display: flex;
+  align-items: baseline;
+  padding: 3px 0;
+  font-size: 13px;
+}
+
+.info-label {
+  color: #888;
+  width: 140px;
+  flex-shrink: 0;
+}
+
+.info-value {
+  color: #333;
+  flex: 1;
+}
+
+.cito-badge {
+  display: inline-block;
+  background: #ff6b6b;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  border-radius: 3px;
+  padding: 2px 6px;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+}
+
+.info-block {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #f0f0f0;
+  max-width: 800px;
+}
+
+.info-block-label {
+  font-weight: 500;
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.info-block-text {
+  background: #f9f9f9;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: #333;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.4;
+}
+
+.info-value .a-under + .a-under {
+  margin-left: 10px;
+}
+
+.image-modal-body {
+  padding: 15px;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.details-section {
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eee;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+}
+
+.section-title {
+  font-weight: 600;
+  color: #049372;
+  font-size: 13px;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-row {
+  display: flex;
+  margin-bottom: 4px;
+}
+
+.detail-label {
+  font-weight: 600;
+  color: #333;
+  min-width: 140px;
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.detail-value {
+  color: #666;
+  margin-left: 8px;
+  flex: 1;
+  font-size: 13px;
+  word-break: break-word;
+
+  &.small-text {
+    font-size: 11px;
+    font-family: 'Courier New', monospace;
+  }
+
+  &.empty-value {
+    color: #999;
+    font-style: italic;
   }
 }
 </style>

--- a/l2-frontend/src/pages/ResultsParaclinic.vue
+++ b/l2-frontend/src/pages/ResultsParaclinic.vue
@@ -644,6 +644,7 @@
         </div>
       </div>
       <div class="results-editor">
+        <slot name="before-researches" />
         <div
           v-for="row in data.researches"
           :key="row.pk"


### PR DESCRIPTION
- Updated `get_requests` function to support date range filtering and pagination with offset and limit.
- Enhanced the request response to include total count and a flag for more data availability.
- Improved the `Collapse` component to accept a background color prop and dynamically set styles.
- Added a new modal for displaying image details in the `RequestsFill` page.
- Introduced a new checkbox filter for requests created by the logged-in user.
- Refactored the request history to include additional fields such as creator and research date.
- Implemented lazy loading for request items and a banner for new items in the request list.
- Updated styles for better UI consistency and usability.

## Описание изменений

_для ускорения проверки лучше заполнить описание изменений тут_

----------------------------------------------------------------------------

Все обязательные проверки (с пометкой required) должны быть без ошибок.

При падении проверок Lint лучше локально запустить `black` на файлах из pull request.

Например `black results/forms/forms107.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds backend date-range filtering and pagination with enriched request payloads, and updates the UI with DateRange, “only mine” filter, infinite scroll/auto-refresh, details/print actions, and an image details modal.
> 
> - **Backend (api/requests)**:
>   - **List API (`get_requests`)**: add `dateFrom`/`dateTo` range filtering, `offset`/`limit` pagination, optional `onlyMine`, hospital-aware filtering; include `hasResult`, `creator`, `files`; return `total` and `hasMore`.
>   - **Params API (`get_request_params`)**: return structured fields (`creator`, `createdAt`, `researchDate`, `dose`, `contrastAmount`, `isCito`, `hasImage`, optional `imageData`, `files`).
>   - Query optimizations: broader `select_related`/`prefetch_related` usage in request/detail handlers.
> - **Frontend**:
>   - **Request history (`RequestHistory.vue`)**:
>     - Replace single-date with `DateRange`, add search modes (my/card/org) and “only mine” filter.
>     - Infinite scroll (`offset`/`limit`) with `IntersectionObserver`; auto-refresh with “new items” banner; merge updates in-place.
>     - Show creator, compact time formatting, files list; add “Print result” button; request details modal.
>   - **Request creation (`index.vue`)**: switch `RequestFields` to `:value`/`@input`; notify history via `handleNewRequestCreated`.
>   - **Requests fill (`RequestsFill/index.vue`)**: show request info panel before researches using new slot; add image details modal; reset details on context change.
>   - **Results editor (`ResultsParaclinic.vue`)**: expose `<slot name="before-researches">`.
>   - **Component (`Collapse.vue`)**: support `bgColor` via CSS var and computed `contentStyle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cb60b8fbd6d0e8a6cd9d9bf6682a78c9dc7d336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->